### PR TITLE
Notebook about Random Forest classification of a Sentinel-2 image

### DIFF
--- a/geo/.tests
+++ b/geo/.tests
@@ -1,1 +1,2 @@
 odata_basics.ipynb
+random_forest_classification_copernicus.ipynb

--- a/geo/random_forest_classification_copernicus.ipynb
+++ b/geo/random_forest_classification_copernicus.ipynb
@@ -1,0 +1,1866 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mwE2BdYd3Ae9"
+   },
+   "source": [
+    "# Introduction\n",
+    "This notebook illustrates how to perform Random Forest classification of a Sentinel-2 image using [Remotior Sensus\n",
+    "](https://fromgistors.blogspot.com/p/remotior-sensus.html).\n",
+    "\n",
+    "> **Remotior Sensus** *(which is Latin for “a more remote sense”) is a Python package that allows for the processing of remote sensing images and GIS data*.\n",
+    "*Other tutorials are available [here](https://remotior-sensus.readthedocs.io/en/latest/basic_tutorials.html).*\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "M00nyJiZi66c"
+   },
+   "source": [
+    "# Install Remotior Sensus and start a new Session\n",
+    "\n",
+    "First, we install Remotior Sensus using Pip."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "M43DBcMlNDRh",
+    "outputId": "e261033b-6363-4f54-a4dd-eab57b9ba05d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: remotior_sensus in /opt/conda/envs/geo/lib/python3.11/site-packages (0.1.24)\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install -U remotior_sensus"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "9zA76xEA3iBT"
+   },
+   "source": [
+    "\n",
+    "We import Remotior Sensus and **start a Remotior Sensus’** [**session**](https://remotior-sensus.readthedocs.io/en/latest/remotior_sensus.core.session.html), defining the number of processes (`n_processes`) and RAM (`available_ram`) available in the system.\n",
+    "\n",
+    ">*For further information about sessions, please read the [User Manual](https://remotior-sensus.readthedocs.io).*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "zuoVUOU1NO17"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO[2023-12-08T19:46:41.210] system_tools.get_system_info[38] version:0.1.24; system: Linux; 64bit: True; n_processes: 2; ram: 3640; temp.dir: /tmp/remotior_sensus_12081jxz9hxk\n",
+      "WARNING[2023-12-08T19:46:41.213] session._check_dependencies[457] No module named 'torch'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "⚠ warning: dependency error: pytorch\n"
+     ]
+    }
+   ],
+   "source": [
+    "import remotior_sensus\n",
+    "\n",
+    "rs = remotior_sensus.Session(n_processes=2, available_ram=3640)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sYdygmxLOm1p"
+   },
+   "source": [
+    "# Prepare Input Data\n",
+    "\n",
+    "For the classification we need to:\n",
+    "\n",
+    "1. Create a BandSet using an image\n",
+    "2. Load a training input\n",
+    "3. Perform the random forest classification\n",
+    "\n",
+    "A [**BandSet**](https://remotior-sensus.readthedocs.io/en/latest/remotior_sensus.core.bandset_catalog.html#remotior_sensus.core.bandset_catalog.BandSet) is an object that includes information about bands (from the file path to the spatial and spectral characteristics).\n",
+    "\n",
+    "We can define a working directory where data of this tutorial are saved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "id": "zZ7Ya5Do2WA-"
+   },
+   "outputs": [],
+   "source": [
+    "working_directory = \"mystorage\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6_l9-9HjDDey"
+   },
+   "source": [
+    "\n",
+    "Before creating the BandSet we should prepare input data.\n",
+    "For the purpose of this tutorial, in order to reduce computation time, we are going to download a Copernicus Sentinel-2 image which includes the following bands.\n",
+    "\n",
+    "| Sentinel-2 Bands                    | Central Wavelength  [micrometers]   |  Resolution [meters]   |\n",
+    "|-------------------------------------|-------------------------------------|------------------------|\n",
+    "| Band 2 - Blue                       | 0.490                               |  10                    |\n",
+    "| Band 3 - Green                      |  0.560                              |  10                    |\n",
+    "| Band 4 - Red                        | 0.665                               |  10                    |\n",
+    "| Band 5 - Vegetation Red Edge        | 0.705                               |  20                    |\n",
+    "| Band 6 - Vegetation Red Edge        | 0.740                               |  20                    |\n",
+    "| Band 7 - Vegetation Red Edge        | 0.783                               |  20                    |\n",
+    "| Band 8 - NIR                        | 0.842                               |  10                    |\n",
+    "| Band 8A - Vegetation Red Edge       | 0.865                               |  20                    |\n",
+    "| Band 11 - SWIR                      | 1.610                               |  20                    |\n",
+    "| Band 12 - SWIR                      | 2.190                               |  20                    |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Image Search\n",
+    "\n",
+    "For downloading Copernicus images we need to enter user and password of the https://dataspace.copernicus.eu.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "id": "xXdeCVGrDDLt",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Copernicus user:  ········\n",
+      "Copernicus password:  ········\n"
+     ]
+    }
+   ],
+   "source": [
+    "from getpass import getpass\n",
+    "import certifi\n",
+    "import os\n",
+    "\n",
+    "# Provide CDSE account credentials - replace with your own data\n",
+    "user = os.environ[\"CDSE_USERNAME\"]\n",
+    "password = os.environ[\"CDSE_PASSWORD\"]\n",
+    "\n",
+    "# user = getpass('Copernicus user: ')\n",
+    "# password = getpass('Copernicus password: ')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "We use the function [**download_products.search**](https://remotior-sensus.readthedocs.io/en/latest/remotior_sensus.tools.download_products.html#remotior_sensus.tools.download_products.search) to **query the Sentinel-2 database** and retrieve a table of available images:\n",
+    "* `name_filter` allows for searching images that match a **tile name**\n",
+    "* `date_from` and `date_to` set a period range\n",
+    "* `max_cloud_cover` sets a threshold for **maximum cloud cover**\n",
+    "* `result_number` returns a limited number of results, in this case 1 image\n",
+    "\n",
+    "> For more information about how to download data using Remotior Sensus please read\n",
+    "[this tutorial\n",
+    "](https://remotior-sensus.readthedocs.io/en/latest/tutorial_ndvi.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO[2023-12-08T19:46:52.080] download_products.query_sentinel_2_database[114] start\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): identity.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://identity.dataspace.copernicus.eu:443 \"POST /auth/realms/CDSE/protocol/openid-connect/token HTTP/1.1\" 200 3354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " search [ 90%]:search in progress ⚙\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): catalogue.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://catalogue.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(MTD_MSIL2A.xml)/$value HTTP/1.1\" 301 162\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): zipper.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(MTD_MSIL2A.xml)/$value HTTP/1.1\" 200 54928\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(MTD_MSIL2A.xml)/$value HTTP/1.1\" 200 54928\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): identity.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://identity.dataspace.copernicus.eu:443 \"DELETE /auth/realms/CDSE/account/sessions/824f7223-d631-41c5-a3ca-50466e494162 HTTP/1.1\" 204 0\n",
+      "INFO[2023-12-08T19:46:59.370] download_products.query_sentinel_2_database[429] end\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " search [100%]: ⬤\u001b[K"
+     ]
+    }
+   ],
+   "source": [
+    "query_result = rs.download_products.search(\n",
+    "    product=\"Sentinel-2\",\n",
+    "    name_filter=\"32TPR\",\n",
+    "    date_from=\"2023-07-01\",\n",
+    "    date_to=\"2023-07-30\",\n",
+    "    max_cloud_cover=10,\n",
+    "    result_number=1,\n",
+    "    copernicus_user=user,\n",
+    "    copernicus_password=password,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The query_result is an object OutputManager including a product table (NumPy recarray) that we can retrive with the attribute extra['product_table\n",
+    "We can have a look at the **table fields**, which include information such as acquisition date, cloud cover, and a preview link. For instance, we can read the records of the first image in the table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         product: Sentinel-2\n",
+      "           image: L2A_T32TPR_A033081_20230707T101428\n",
+      "      product_id: S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302\n",
+      "acquisition_date: 2023-07-07\n",
+      "     cloud_cover: 3\n",
+      "       zone_path: 32TPR\n",
+      "             row: None\n",
+      "         min_lat: 45.034190140253\n",
+      "         min_lon: 10.2700756717775\n",
+      "         max_lat: 46.0462654563034\n",
+      "         max_lon: 11.7105441475977\n",
+      "      collection: None\n",
+      "            size: 1\n",
+      "         preview: https://catalogue.dataspace.copernicus.eu/odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(QI_DATA)/Nodes(T32TPR_20230707T100559_PVI.jp2)/$value\n",
+      "             uid: 302382f3-fb33-4a3a-a5db-5836451b374e\n",
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "product_table = query_result.extra[\"product_table\"]\n",
+    "print(print(product_table[0].pprint()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can display an image preview.\n",
+    "`product_table.preview[0]` is the url of the preview of the first product in the table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): identity.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://identity.dataspace.copernicus.eu:443 \"POST /auth/realms/CDSE/protocol/openid-connect/token HTTP/1.1\" 200 3354\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): catalogue.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://catalogue.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(QI_DATA)/Nodes(T32TPR_20230707T100559_PVI.jp2)/$value HTTP/1.1\" 301 162\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): zipper.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(QI_DATA)/Nodes(T32TPR_20230707T100559_PVI.jp2)/$value HTTP/1.1\" 200 165826\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(QI_DATA)/Nodes(T32TPR_20230707T100559_PVI.jp2)/$value HTTP/1.1\" 200 165826\n"
+     ]
+    }
+   ],
+   "source": [
+    "access_token, session_state = rs.download_products.get_copernicus_token(\n",
+    "    user=user, password=password\n",
+    ")\n",
+    "temp_file = rs.configurations.temp.temporary_file_path(name_suffix=\".jp2\")\n",
+    "check = rs.configurations.multiprocess.multi_download_file(\n",
+    "    url_list=[product_table.preview[0]],\n",
+    "    output_path_list=[temp_file],\n",
+    "    access_token=access_token,\n",
+    "    copernicus=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Figure\n",
+    "from osgeo import gdal\n",
+    "import numpy\n",
+    "import matplotlib.colors as mcolors\n",
+    "import matplotlib.patches as mpatches\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "raster = gdal.Open(temp_file)\n",
+    "blue_band = raster.GetRasterBand(1).ReadAsArray()\n",
+    "green_band = raster.GetRasterBand(2).ReadAsArray()\n",
+    "red_band = raster.GetRasterBand(3).ReadAsArray()\n",
+    "image = numpy.stack((red_band, green_band, blue_band), axis=-1)\n",
+    "plt.imshow(image)\n",
+    "plt.rcParams[\"figure.figsize\"] = (15, 15)\n",
+    "plt.axis(\"off\")\n",
+    "plt.show()\n",
+    "band = image = plt = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To download the images, we use the function [**download_products.download**](https://remotior-sensus.readthedocs.io/en/latest/remotior_sensus.tools.download_products.html#remotior_sensus.tools.download_products.download) and download the 10m and 20m bands:\n",
+    "* `product_table` sets the images to be downloaded from the previously query results (in this case one image)\n",
+    "* `band_list` defines a list of band names which for Sentinel-2 are: `'02', '03', '04', '05', '06', '07', '08', '8a', '11', '12'`.\n",
+    "* `output_path` defines where downloaded files are saved.\n",
+    "\n",
+    "During the download, a directory inside the `output_directory` is created for the downloaded image.\n",
+    "\n",
+    "> `downloaded_image` is an an object [**OutputManager**](https://remotior-sensus.readthedocs.io/en/latest/remotior_sensus.core.output_manager.html) that includes a list of created directories in the attribute `extra['directory_paths']`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO[2023-12-08T19:48:28.451] download_products.download[542] start\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): identity.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://identity.dataspace.copernicus.eu:443 \"POST /auth/realms/CDSE/protocol/openid-connect/token HTTP/1.1\" 200 3354\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): catalogue.dataspace.copernicus.eu:443\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [  0%]:starting ⚙\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:https://catalogue.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(MTD_MSIL2A.xml)/$value HTTP/1.1\" 301 162\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): zipper.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(MTD_MSIL2A.xml)/$value HTTP/1.1\" 200 54928\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(MTD_MSIL2A.xml)/$value HTTP/1.1\" 200 54928\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): catalogue.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://catalogue.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R10m)/Nodes(T32TPR_20230707T100559_B02_10m.jp2)/$value HTTP/1.1\" 301 162\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): zipper.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R10m)/Nodes(T32TPR_20230707T100559_B02_10m.jp2)/$value HTTP/1.1\" 200 119714873\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [  0%] starting ⚙\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R10m)/Nodes(T32TPR_20230707T100559_B02_10m.jp2)/$value HTTP/1.1\" 200 119714873\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [  7%] [elapsed 0min14sec] [remaining 3min16sec] downloading band 02 ◑\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR[2023-12-08T19:48:44.207] multiprocess_manager.multi_download_file[2353] Error proc 0-['mystorage/downloaded_images/L2A_T32TPR_A033081_20230707T101428_2023-07-07/T32TPR_A033081_20230707T101428_B02.jp2']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [  8%] [elapsed 0min15sec] [remaining 3min01sec] downloading band 02 ◕\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): catalogue.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://catalogue.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R10m)/Nodes(T32TPR_20230707T100559_B03_10m.jp2)/$value HTTP/1.1\" 301 162\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): zipper.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R10m)/Nodes(T32TPR_20230707T100559_B03_10m.jp2)/$value HTTP/1.1\" 200 123641935\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [  8%] [elapsed 0min26sec] [remaining 3min01sec]:downloading band 02 ◕\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R10m)/Nodes(T32TPR_20230707T100559_B03_10m.jp2)/$value HTTP/1.1\" 200 123641935\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 19%] [elapsed 0min46sec] [remaining 3min20sec]:downloading band 03 ◕\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR[2023-12-08T19:49:16.349] multiprocess_manager.multi_download_file[2353] Error proc 0-['mystorage/downloaded_images/L2A_T32TPR_A033081_20230707T101428_2023-07-07/T32TPR_A033081_20230707T101428_B03.jp2']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 20%] [elapsed 0min47sec] [remaining 3min12sec]:downloading band 03 ⬤\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): catalogue.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://catalogue.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R10m)/Nodes(T32TPR_20230707T100559_B04_10m.jp2)/$value HTTP/1.1\" 301 162\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): zipper.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R10m)/Nodes(T32TPR_20230707T100559_B04_10m.jp2)/$value HTTP/1.1\" 200 123801853\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 20%] [elapsed 0min52sec] [remaining 3min12sec] downloading band 03 ⬤\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R10m)/Nodes(T32TPR_20230707T100559_B04_10m.jp2)/$value HTTP/1.1\" 200 123801853\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 27%] [elapsed 1min01sec] [remaining 2min48sec]:downloading band 04 ◑\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR[2023-12-08T19:49:31.429] multiprocess_manager.multi_download_file[2353] Error proc 0-['mystorage/downloaded_images/L2A_T32TPR_A033081_20230707T101428_2023-07-07/T32TPR_A033081_20230707T101428_B04.jp2']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 27%] [elapsed 1min02sec] [remaining 2min48sec]:downloading band 04 ◕\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): catalogue.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://catalogue.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B05_20m.jp2)/$value HTTP/1.1\" 301 162\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): zipper.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B05_20m.jp2)/$value HTTP/1.1\" 200 33830920\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 27%] [elapsed 1min04sec] [remaining 2min48sec] downloading band 04 ◕\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B05_20m.jp2)/$value HTTP/1.1\" 200 33830920\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 31%] [elapsed 1min06sec] [remaining 2min27sec] downloading band 05 ○\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR[2023-12-08T19:49:35.479] multiprocess_manager.multi_download_file[2353] Error proc 0-['mystorage/downloaded_images/L2A_T32TPR_A033081_20230707T101428_2023-07-07/T32TPR_A033081_20230707T101428_B05.jp2']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 31%] [elapsed 1min07sec] [remaining 2min27sec] downloading band 05 ○\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): catalogue.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://catalogue.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B06_20m.jp2)/$value HTTP/1.1\" 301 162\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): zipper.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B06_20m.jp2)/$value HTTP/1.1\" 200 33738033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 31%] [elapsed 1min08sec] [remaining 2min27sec]:downloading band 05 ○\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B06_20m.jp2)/$value HTTP/1.1\" 200 33738033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 42%] [elapsed 1min11sec] [remaining 1min38sec]:downloading band 06 ○\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR[2023-12-08T19:49:40.546] multiprocess_manager.multi_download_file[2353] Error proc 0-['mystorage/downloaded_images/L2A_T32TPR_A033081_20230707T101428_2023-07-07/T32TPR_A033081_20230707T101428_B06.jp2']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 42%] [elapsed 1min12sec] [remaining 1min38sec]:downloading band 06 ◔\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): catalogue.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://catalogue.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B07_20m.jp2)/$value HTTP/1.1\" 301 162\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): zipper.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B07_20m.jp2)/$value HTTP/1.1\" 200 33778240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 42%] [elapsed 1min13sec] [remaining 1min38sec] downloading band 06 ◔\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B07_20m.jp2)/$value HTTP/1.1\" 200 33778240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 50%] [elapsed 1min15sec] [remaining 1min14sec] downloading band 07 ○\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR[2023-12-08T19:49:44.596] multiprocess_manager.multi_download_file[2353] Error proc 0-['mystorage/downloaded_images/L2A_T32TPR_A033081_20230707T101428_2023-07-07/T32TPR_A033081_20230707T101428_B07.jp2']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 51%] [elapsed 1min16sec] [remaining 1min13sec] downloading band 07 ○\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): catalogue.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://catalogue.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R10m)/Nodes(T32TPR_20230707T100559_B08_10m.jp2)/$value HTTP/1.1\" 301 162\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): zipper.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R10m)/Nodes(T32TPR_20230707T100559_B08_10m.jp2)/$value HTTP/1.1\" 200 135422775\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 51%] [elapsed 1min22sec] [remaining 1min13sec] downloading band 07 ○\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R10m)/Nodes(T32TPR_20230707T100559_B08_10m.jp2)/$value HTTP/1.1\" 200 135422775\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 68%] [elapsed 1min31sec] [remaining 0min43sec] downloading band 08 ◕\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR[2023-12-08T19:50:00.667] multiprocess_manager.multi_download_file[2353] Error proc 0-['mystorage/downloaded_images/L2A_T32TPR_A033081_20230707T101428_2023-07-07/T32TPR_A033081_20230707T101428_B08.jp2']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 68%] [elapsed 1min32sec] [remaining 0min43sec] downloading band 08 ◕\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): catalogue.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://catalogue.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B8A_20m.jp2)/$value HTTP/1.1\" 301 162\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): zipper.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B8A_20m.jp2)/$value HTTP/1.1\" 200 33806787\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 68%] [elapsed 1min37sec] [remaining 0min43sec]:downloading band 08 ◕\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B8A_20m.jp2)/$value HTTP/1.1\" 200 33806787\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 77%] [elapsed 1min46sec] [remaining 0min31sec]:downloading band 8A ◕\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR[2023-12-08T19:50:15.756] multiprocess_manager.multi_download_file[2353] Error proc 0-['mystorage/downloaded_images/L2A_T32TPR_A033081_20230707T101428_2023-07-07/T32TPR_A033081_20230707T101428_B8A.jp2']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 79%] [elapsed 1min47sec] [remaining 0min29sec]:downloading band 8A ◕\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): catalogue.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://catalogue.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B11_20m.jp2)/$value HTTP/1.1\" 301 162\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): zipper.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B11_20m.jp2)/$value HTTP/1.1\" 200 33738369\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 79%] [elapsed 1min51sec] [remaining 0min29sec]:downloading band 8A ◕\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B11_20m.jp2)/$value HTTP/1.1\" 200 33738369\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 86%] [elapsed 1min59sec] [remaining 0min19sec] downloading band 11 ◑\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR[2023-12-08T19:50:28.848] multiprocess_manager.multi_download_file[2353] Error proc 0-['mystorage/downloaded_images/L2A_T32TPR_A033081_20230707T101428_2023-07-07/T32TPR_A033081_20230707T101428_B11.jp2']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 86%] [elapsed 2min00sec] [remaining 0min19sec] downloading band 11 ◑\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): catalogue.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://catalogue.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B12_20m.jp2)/$value HTTP/1.1\" 301 162\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): zipper.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B12_20m.jp2)/$value HTTP/1.1\" 200 33832340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 86%] [elapsed 2min04sec] [remaining 0min19sec] downloading band 11 ◑\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:https://zipper.dataspace.copernicus.eu:443 \"GET /odata/v1/Products(302382f3-fb33-4a3a-a5db-5836451b374e)/Nodes(S2B_MSIL2A_20230707T100559_N0509_R022_T32TPR_20230707T131302.SAFE)/Nodes(GRANULE)/Nodes(L2A_T32TPR_A033081_20230707T101428)/Nodes(IMG_DATA)/Nodes(R20m)/Nodes(T32TPR_20230707T100559_B12_20m.jp2)/$value HTTP/1.1\" 200 33832340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [ 98%] [elapsed 2min37sec] [remaining 0min03sec]:downloading band 12 ◕\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR[2023-12-08T19:51:06.917] multiprocess_manager.multi_download_file[2353] Error proc 0-['mystorage/downloaded_images/L2A_T32TPR_A033081_20230707T101428_2023-07-07/T32TPR_A033081_20230707T101428_B12.jp2']\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): identity.dataspace.copernicus.eu:443\n",
+      "DEBUG:urllib3.connectionpool:https://identity.dataspace.copernicus.eu:443 \"DELETE /auth/realms/CDSE/account/sessions/048a4a12-1a2c-443a-b12a-5818625c2036 HTTP/1.1\" 204 0\n",
+      "INFO[2023-12-08T19:51:07.013] download_products.download[857] end\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " download products [100%] [elapsed 2min38sec]: ⬤\u001b[K['mystorage/downloaded_images/L2A_T32TPR_A033081_20230707T101428_2023-07-07']\n"
+     ]
+    }
+   ],
+   "source": [
+    "downloaded_image = rs.download_products.download(\n",
+    "    product_table=product_table,\n",
+    "    band_list=[\"02\", \"03\", \"04\", \"05\", \"06\", \"07\", \"08\", \"8A\", \"11\", \"12\"],\n",
+    "    output_path=working_directory + \"/downloaded_images\",\n",
+    "    copernicus_user=user,\n",
+    "    copernicus_password=password,\n",
+    ")\n",
+    "\n",
+    "print(downloaded_image.extra[\"directory_paths\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data Preprocessing\n",
+    "To preprocess the images (converte from digital numbers to decimal values of reflectance) we use the function [**preprocess_products.preprocess**](https://remotior-sensus.readthedocs.io/en/latest/remotior_sensus.tools.preprocess_products.html#remotior_sensus.tools.preprocess_products.preprocess):\n",
+    "* `sensor` sets the sensor of input image, in this case `'Sentinel-2'`\n",
+    "* `input_path` accepts a directory containing the image bands, which in this case we get from `downloaded_image.extra['directory_paths'][0]`\n",
+    "* `output_path` sets output directory where converted bands are saved, in this case `output_path=working_directory + '/preprocessed'`\n",
+    "* `nodata_value` allows for masking image NoData by value.\n",
+    "\n",
+    "Defining a list `preprocessed_image_directories` is convenient to retrieve the directories of preprocessed images that we are going to use later.\n",
+    "The process can take a few minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO[2023-12-08T19:51:07.525] preprocess_products.perform_preprocess[137] start\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " preprocess products [  0%]:starting ⚙\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/envs/geo/lib/python3.11/site-packages/remotior_sensus/core/processor.py:536: RuntimeWarning: invalid value encountered in cast\n",
+      "  value_as_nodata = np.asarray(value_as_nodata).astype(\n",
+      "/opt/conda/envs/geo/lib/python3.11/site-packages/remotior_sensus/core/processor.py:536: RuntimeWarning: invalid value encountered in cast\n",
+      "  value_as_nodata = np.asarray(value_as_nodata).astype(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " preprocess products [ 89%] [elapsed 4min13sec] [remaining 0min31sec]:processing ⬤\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO[2023-12-08T19:55:22.363] preprocess_products.perform_preprocess[628] end; preprocess products: ['mystorage/preprocessed/T32TPR_A033081_20230707T101428_B02.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B03.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B04.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B05.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B06.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B07.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B08.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B11.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B12.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B8A.tif']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " preprocess products [100%] [elapsed 4min14sec]: ⬤\u001b[Kining 0min31sec] processing ⚙\u001b[K"
+     ]
+    }
+   ],
+   "source": [
+    "preprocessed = rs.preprocess_products.preprocess(\n",
+    "    sensor=\"Sentinel-2\",\n",
+    "    input_path=downloaded_image.extra[\"directory_paths\"][0],\n",
+    "    output_path=working_directory + \"/preprocessed\",\n",
+    "    nodata_value=0,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3r8dE73w8SEc"
+   },
+   "source": [
+    "# 1 Create the Input Bandset\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "13gi00YjOokM"
+   },
+   "source": [
+    "Now, we create a [**BandSet Catalog**](https://remotior-sensus.readthedocs.io/en/latest/remotior_sensus.core.bandset_catalog.html) which contains BandSets (note that an empty BandSet 1 will be automatically created)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "id": "hSDilKsVHsJ7"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO[2023-12-08T19:55:22.377] bandset_catalog.create[744] start\n",
+      "INFO[2023-12-08T19:55:22.380] bandset_catalog.create[751] end\n"
+     ]
+    }
+   ],
+   "source": [
+    "catalog = rs.bandset_catalog()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Ssdm8t-ZO4aW"
+   },
+   "source": [
+    "Now we create a BandSet using `catalog.create_bandset`:\n",
+    "* `paths` defines the list of paths to the bands, in this case the directory of preprocessed files `[working_directory + '/preprocessed']` can be used to get all the bands inside this directory\n",
+    "* `bandset_number` explicitly sets the number of the BandSet as 1\n",
+    "* `wavelengths` sets a listo of values as the center wavelength for each band, in this case `['Sentinel-2']` automatically defines Sentinel-2 values for the identified bands in the BandSet\n",
+    "\n",
+    "Optionally, we can set the `box_coordinate_list` argument as list of coordinates [left, top, right, bottom] to create a virtual subset and reduce computation time for a smaller area of interest."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "yZRvCQPbOzyW",
+    "outputId": "7ccf2192-1499-42b1-9bbc-9ba6357b4189"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO[2023-12-08T19:55:22.393] bandset_catalog.create[744] start\n",
+      "INFO[2023-12-08T19:55:22.983] bandset_catalog.create[948] end; file list: ['mystorage/preprocessed/T32TPR_A033081_20230707T101428_B02.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B03.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B04.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B05.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B06.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B07.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B08.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B11.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B12.tif', 'mystorage/preprocessed/T32TPR_A033081_20230707T101428_B8A.tif']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<remotior_sensus.core.bandset_catalog.BandSet at 0x7efba8bb8490>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "catalog.create_bandset(\n",
+    "    paths=[working_directory + \"/preprocessed\"],\n",
+    "    bandset_number=1,\n",
+    "    wavelengths=[\"Sentinel-2\"],\n",
+    "    box_coordinate_list=[629000, 5036000, 641000, 5028000],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We get the first BandSet in the catalog with the function `catalog.get(1)`, then we can print the created BandSet with the BandSet function `print()`. This is the input that is going to be classified."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "name: T32TPR_A033081_20230707T101428_B \n",
+      "date: NaT \n",
+      "root directory: None \n",
+      "crs: PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]] \n",
+      "box coordinate left │  629000 \n",
+      "box coordinate top │  5036000 \n",
+      "box coordinate right │  641000 \n",
+      "box coordinate bottom │  5028000 \n",
+      "┌─────────────┬─────────────┬───────────────────────────────────────────────────────────────┬────────────────┬────────────────────────────────────┬────────────┬─────────────────┬─────────────────┬───────────────────────┬──────┬────────┬────────┬───────────┬──────────┬───────────┬──────────┬─────────┬─────────┬────────┬───────────┬─────────────────┬──────────────┬──────────────┬────────┬────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐ \n",
+      "│ band_number │ raster_band │ path                                                          │ root_directory │ name                               │ wavelength │ wavelength_unit │ additive_factor │ multiplicative_factor │ date │ x_size │ y_size │ top       │ left     │ bottom    │ right    │ x_count │ y_count │ nodata │ data_type │ number_of_bands │ x_block_size │ y_block_size │ scale  │ offset │ crs                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  │ \n",
+      "├─────────────┼─────────────┼───────────────────────────────────────────────────────────────┼────────────────┼────────────────────────────────────┼────────────┼─────────────────┼─────────────────┼───────────────────────┼──────┼────────┼────────┼───────────┼──────────┼───────────┼──────────┼─────────┼─────────┼────────┼───────────┼─────────────────┼──────────────┼──────────────┼────────┼────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤ \n",
+      "│ 1           │ 1           │ mystorage/preprocessed/T32TPR_A033081_20230707T101428_B02.tif │ None           │ T32TPR_A033081_20230707T101428_B02 │ 0.49       │ µm (1 E-6m)     │ 0.0             │ 1.0                   │ NaT  │ 10.0   │ 10.0   │ 5100000.0 │ 600000.0 │ 4990200.0 │ 709800.0 │ 10980   │ 10980   │ 65535  │ UInt16    │ 1               │ 10980        │ 1            │ 0.0001 │ 0.0    │ PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]] │ \n",
+      "│ 2           │ 1           │ mystorage/preprocessed/T32TPR_A033081_20230707T101428_B03.tif │ None           │ T32TPR_A033081_20230707T101428_B03 │ 0.56       │ µm (1 E-6m)     │ 0.0             │ 1.0                   │ NaT  │ 10.0   │ 10.0   │ 5100000.0 │ 600000.0 │ 4990200.0 │ 709800.0 │ 10980   │ 10980   │ 65535  │ UInt16    │ 1               │ 10980        │ 1            │ 0.0001 │ 0.0    │ PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]] │ \n",
+      "│ 3           │ 1           │ mystorage/preprocessed/T32TPR_A033081_20230707T101428_B04.tif │ None           │ T32TPR_A033081_20230707T101428_B04 │ 0.665      │ µm (1 E-6m)     │ 0.0             │ 1.0                   │ NaT  │ 10.0   │ 10.0   │ 5100000.0 │ 600000.0 │ 4990200.0 │ 709800.0 │ 10980   │ 10980   │ 65535  │ UInt16    │ 1               │ 10980        │ 1            │ 0.0001 │ 0.0    │ PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]] │ \n",
+      "│ 4           │ 1           │ mystorage/preprocessed/T32TPR_A033081_20230707T101428_B05.tif │ None           │ T32TPR_A033081_20230707T101428_B05 │ 0.705      │ µm (1 E-6m)     │ 0.0             │ 1.0                   │ NaT  │ 20.0   │ 20.0   │ 5100000.0 │ 600000.0 │ 4990200.0 │ 709800.0 │ 5490    │ 5490    │ 65535  │ UInt16    │ 1               │ 5490         │ 1            │ 0.0001 │ 0.0    │ PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]] │ \n",
+      "│ 5           │ 1           │ mystorage/preprocessed/T32TPR_A033081_20230707T101428_B06.tif │ None           │ T32TPR_A033081_20230707T101428_B06 │ 0.74       │ µm (1 E-6m)     │ 0.0             │ 1.0                   │ NaT  │ 20.0   │ 20.0   │ 5100000.0 │ 600000.0 │ 4990200.0 │ 709800.0 │ 5490    │ 5490    │ 65535  │ UInt16    │ 1               │ 5490         │ 1            │ 0.0001 │ 0.0    │ PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]] │ \n",
+      "│ 6           │ 1           │ mystorage/preprocessed/T32TPR_A033081_20230707T101428_B07.tif │ None           │ T32TPR_A033081_20230707T101428_B07 │ 0.783      │ µm (1 E-6m)     │ 0.0             │ 1.0                   │ NaT  │ 20.0   │ 20.0   │ 5100000.0 │ 600000.0 │ 4990200.0 │ 709800.0 │ 5490    │ 5490    │ 65535  │ UInt16    │ 1               │ 5490         │ 1            │ 0.0001 │ 0.0    │ PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]] │ \n",
+      "│ 7           │ 1           │ mystorage/preprocessed/T32TPR_A033081_20230707T101428_B08.tif │ None           │ T32TPR_A033081_20230707T101428_B08 │ 0.842      │ µm (1 E-6m)     │ 0.0             │ 1.0                   │ NaT  │ 10.0   │ 10.0   │ 5100000.0 │ 600000.0 │ 4990200.0 │ 709800.0 │ 10980   │ 10980   │ 65535  │ UInt16    │ 1               │ 10980        │ 1            │ 0.0001 │ 0.0    │ PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]] │ \n",
+      "│ 8           │ 1           │ mystorage/preprocessed/T32TPR_A033081_20230707T101428_B11.tif │ None           │ T32TPR_A033081_20230707T101428_B11 │ 1.61       │ µm (1 E-6m)     │ 0.0             │ 1.0                   │ NaT  │ 20.0   │ 20.0   │ 5100000.0 │ 600000.0 │ 4990200.0 │ 709800.0 │ 5490    │ 5490    │ 65535  │ UInt16    │ 1               │ 5490         │ 1            │ 0.0001 │ 0.0    │ PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]] │ \n",
+      "│ 9           │ 1           │ mystorage/preprocessed/T32TPR_A033081_20230707T101428_B12.tif │ None           │ T32TPR_A033081_20230707T101428_B12 │ 2.19       │ µm (1 E-6m)     │ 0.0             │ 1.0                   │ NaT  │ 20.0   │ 20.0   │ 5100000.0 │ 600000.0 │ 4990200.0 │ 709800.0 │ 5490    │ 5490    │ 65535  │ UInt16    │ 1               │ 5490         │ 1            │ 0.0001 │ 0.0    │ PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]] │ \n",
+      "│ 10          │ 1           │ mystorage/preprocessed/T32TPR_A033081_20230707T101428_B8A.tif │ None           │ T32TPR_A033081_20230707T101428_B8A │ 0.865      │ µm (1 E-6m)     │ 0.0             │ 1.0                   │ NaT  │ 20.0   │ 20.0   │ 5100000.0 │ 600000.0 │ 4990200.0 │ 709800.0 │ 5490    │ 5490    │ 65535  │ UInt16    │ 1               │ 5490         │ 1            │ 0.0001 │ 0.0    │ PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]] │ \n",
+      "└─────────────┴─────────────┴───────────────────────────────────────────────────────────────┴────────────────┴────────────────────────────────────┴────────────┴─────────────────┴─────────────────┴───────────────────────┴──────┴────────┴────────┴───────────┴──────────┴───────────┴──────────┴─────────┴─────────┴────────┴───────────┴─────────────────┴──────────────┴──────────────┴────────┴────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘ \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "catalog.get(1).print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can create a virtual raster of the BandSet which we can open in GIS software."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'mystorage/virtual.vrt'"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vrt_file = working_directory + \"/virtual.vrt\"\n",
+    "catalog.create_virtual_raster(bandset_number=1, output_path=vrt_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can display the virtual raster (using matplotlib)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Figure\n",
+    "from osgeo import gdal\n",
+    "import numpy\n",
+    "import matplotlib.colors as mcolors\n",
+    "import matplotlib.patches as mpatches\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "raster = gdal.Open(vrt_file)\n",
+    "blue_band = raster.GetRasterBand(1).ReadAsArray()\n",
+    "green_band = raster.GetRasterBand(2).ReadAsArray()\n",
+    "red_band = raster.GetRasterBand(3).ReadAsArray()\n",
+    "image = numpy.stack((red_band, green_band, blue_band), axis=-1)\n",
+    "image = numpy.clip((image / 10000) / 0.2, 0, 1)\n",
+    "plt.imshow(image)\n",
+    "plt.rcParams[\"figure.figsize\"] = (15, 15)\n",
+    "plt.axis(\"off\")\n",
+    "plt.show()\n",
+    "band = image = plt = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fVlLD1S5Ibfi"
+   },
+   "source": [
+    "# 2 Load the Training Input\n",
+    "\n",
+    "In general, we would need to create a vector file containing polygons (ROIs) used to train the algorithm, where each polygon corresponds to a class (or macroclass).\n",
+    "\n",
+    "In this tutorial, the following macroclasses are considered.\n",
+    "\n",
+    "\n",
+    "|   Macroclass name   |   Macroclass ID   |\n",
+    "|---------------------|-------------------|\n",
+    "|   Water             |   1               |\n",
+    "|   Built-up          |   2               |\n",
+    "|   Vegetation        |   3               |\n",
+    "|   Soil              |   4               |\n",
+    "\n",
+    "For the creation of these polygons, one can use GIS software such as the [Semi-Automatic Classification Plugin](https://semiautomaticclassificationmanual.readthedocs.io) for QGIS.\n",
+    "For the purpose of this tutorial, we are going to download an already prepared geopackage of polygons.\n",
+    "\n",
+    "> More information about **classes and macroclasses** is available [here](https://semiautomaticclassificationmanual.readthedocs.io/it/latest/remote_sensing.html#classes-and-macroclasses).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wTrD5DDhUycI"
+   },
+   "source": [
+    "To open the training input, first we create a **Spectral Signatures Catalog** using [**SpectralSignaturesCatalog**](https://remotior-sensus.readthedocs.io/en/latest/remotior_sensus.core.spectral_signatures.html#remotior_sensus.core.spectral_signatures.SpectralSignaturesCatalog), which must be created specifically for a BandSet (and the characteristics thereof):\n",
+    "\n",
+    "\n",
+    "* `bandset` sets the reference BandSet\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "id": "Y3NA_RskUziB"
+   },
+   "outputs": [],
+   "source": [
+    "bandset_1 = catalog.get(1)\n",
+    "\n",
+    "signature_catalog = rs.spectral_signatures_catalog(bandset=bandset_1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case we are going to create the training polygons using the region growing at specific coordinates, but one can import a vector file ([read this](https://remotior-sensus.readthedocs.io/en/latest/remotior_sensus.core.spectral_signatures.html#remotior_sensus.core.spectral_signatures.SpectralSignaturesCatalog.import_vector))."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " remotior_sensus [  0%]:starting ⚙\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195529805003_8382 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " remotior_sensus [ 57%]:calculate signature ⚙\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195543305856_548 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " remotior_sensus [ 57%] calculate signature ⚙\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195554715835_3024 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " remotior_sensus [ 57%]:calculate signature ⚙\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195607767695_3922 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " remotior_sensus [ 57%]:calculate signature ⚙\u001b[K"
+     ]
+    }
+   ],
+   "source": [
+    "region_path = rs.shared_tools.region_growing_polygon(\n",
+    "    coordinate_x=631837,\n",
+    "    coordinate_y=5034612,\n",
+    "    input_bands=1,\n",
+    "    band_number=1,\n",
+    "    max_width=100,\n",
+    "    max_spectral_distance=0.05,\n",
+    "    minimum_size=10,\n",
+    "    bandset_catalog=catalog,\n",
+    ")\n",
+    "signature_catalog.import_vector(\n",
+    "    file_path=region_path,\n",
+    "    macroclass_value=1,\n",
+    "    class_value=1,\n",
+    "    macroclass_name=\"water\",\n",
+    "    class_name=\"water\",\n",
+    ")\n",
+    "region_path = rs.shared_tools.region_growing_polygon(\n",
+    "    coordinate_x=631859,\n",
+    "    coordinate_y=5032672,\n",
+    "    input_bands=1,\n",
+    "    band_number=1,\n",
+    "    max_width=100,\n",
+    "    max_spectral_distance=0.05,\n",
+    "    minimum_size=10,\n",
+    "    bandset_catalog=catalog,\n",
+    ")\n",
+    "signature_catalog.import_vector(\n",
+    "    file_path=region_path,\n",
+    "    macroclass_value=2,\n",
+    "    class_value=2,\n",
+    "    macroclass_name=\"built-up\",\n",
+    "    class_name=\"built-up\",\n",
+    ")\n",
+    "region_path = rs.shared_tools.region_growing_polygon(\n",
+    "    coordinate_x=630552,\n",
+    "    coordinate_y=5029558,\n",
+    "    input_bands=1,\n",
+    "    band_number=1,\n",
+    "    max_width=100,\n",
+    "    max_spectral_distance=0.05,\n",
+    "    minimum_size=10,\n",
+    "    bandset_catalog=catalog,\n",
+    ")\n",
+    "signature_catalog.import_vector(\n",
+    "    file_path=region_path,\n",
+    "    macroclass_value=3,\n",
+    "    class_value=3,\n",
+    "    macroclass_name=\"vegetation\",\n",
+    "    class_name=\"vegetation\",\n",
+    ")\n",
+    "region_path = rs.shared_tools.region_growing_polygon(\n",
+    "    coordinate_x=631226,\n",
+    "    coordinate_y=5028546,\n",
+    "    input_bands=1,\n",
+    "    band_number=1,\n",
+    "    max_width=100,\n",
+    "    max_spectral_distance=0.05,\n",
+    "    minimum_size=10,\n",
+    "    bandset_catalog=catalog,\n",
+    ")\n",
+    "signature_catalog.import_vector(\n",
+    "    file_path=region_path,\n",
+    "    macroclass_value=4,\n",
+    "    class_value=4,\n",
+    "    macroclass_name=\"soil\",\n",
+    "    class_name=\"soil\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0odWD4MD8TT1"
+   },
+   "source": [
+    "# 3 Perform Random Forest Classification\n",
+    "\n",
+    "We are going to train the **Random Forest** classifier and perform the classification.\n",
+    "\n",
+    "To classify the image we are going to use the tool [**band_classification**](https://remotior-sensus.readthedocs.io/en/latest/remotior_sensus.tools.band_classification.html#remotior_sensus.tools.band_classification.band_classification), with the following parameters:\n",
+    "* `input_bands` is a parameter that accepts a list of input raster paths, or a BandSet number, or a previously defined BandSet\n",
+    "* `bandset_catalog` the catalog containing the BandSet (in case `input_bands` is a BandSet number)\n",
+    "* `spectral_signatures` the SpectralSignaturesCatalog containing the training input\n",
+    "* `macroclass` if True, the training in evaluated on the macroclass ID field; if False, the training is evaluated on the class ID field\n",
+    "* `output_path` sets the output path of the classification raster\n",
+    "* `save_classifier` is an optional parameter, if True saves the classifier to a file to be loaded (without training) for a new classification\n",
+    "* `classification_confidence` is an optional parameter, if True, writes a classification confidence raster as additional output, useful to evaluate the confidence of the classifier at pixel level (from 0=low to 1=high confidence)\n",
+    "* `algorithm_name` is the name of the classification algorithms, which for Random Forest is `'rf'`, other options are:\n",
+    "  * Minimum Distance = 'md'\n",
+    "  * Maximum Likelihood = 'ml'\n",
+    "  * Spectral Angle Mapping = 'sam'\n",
+    "  * Random Forest OneVsRest = 'rf_ovr'\n",
+    "  * Support Vector Machine = 'svm'\n",
+    "  * Multi Layer Perceptron = 'mlp'\n",
+    "  * Multi Layer Perceptron using PyTorch framework = 'pytorch_mlp'\n",
+    "\n",
+    "    classification_confidence=True\n",
+    "Available parameters for **Random Forest** are:\n",
+    "* `rf_max_features` parameter that sets the number of features considered in node splitting; if None all features are considered in node splitting, available options are ‘sqrt’ as square root of all the features, an integer number, or a float number for a fraction of all the features.\n",
+    "* `rf_number_trees` parameter that sets the number of trees in the forest\n",
+    "* `rf_min_samples_split` parameter that sets the minimum number of samples required to split an internal node\n",
+    "\n",
+    "For the purpose of this tutorial we set `rf_number_trees=50` to reduce computation time, but generally it should be at least `rf_number_trees=200` to get good results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "fmaRTgoCmOOn",
+    "outputId": "24d021c0-a464-4d39-8c55-4b4f36f8cd1e"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO[2023-12-08T19:56:16.222] band_classification.band_classification[1255] start\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [  1%] [elapsed 0min00sec] [remaining 0min00sec]:starting the classifier ⚙\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [  1%] [elapsed 0min06sec] [remaining 0min00sec] get band arrays ○\u001b[Kier ⚙\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [  2%] [elapsed 0min07sec] [remaining 6min00sec] get band arrays ◔\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [  2%] [elapsed 0min08sec] [remaining 6min00sec] get band arrays ◑\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [  2%] [elapsed 0min09sec] [remaining 6min00sec]:get band arrays ◑\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [  3%] [elapsed 0min10sec] [remaining 5min35sec]:get band arrays ◕\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n",
+      "Warning 1: A geometry of type POLYGON is inserted into layer t20231208_195524861828_8682 of geometry type MULTIPOLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [  4%] [elapsed 0min11sec] [remaining 4min33sec]:get band arrays ⬤\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO[2023-12-08T19:56:28.034] band_classification.train[450] start\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [  4%] [elapsed 0min17sec] [remaining 4min33sec]:get band arrays ⚙\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=1)]: Done  40 tasks      | elapsed:    5.9s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [  4%] [elapsed 0min23sec] [remaining 4min33sec]:get band arrays ⚙\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=1)]: Done  40 tasks      | elapsed:    5.6s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [ 20%] [elapsed 0min36sec] [remaining 1min47sec]:fitting ⬤\u001b[Kbuilding tree 1 of 50\n",
+      "building tree 2 of 50\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=2)]: Using backend ThreadingBackend with 2 concurrent workers.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "building tree 3 of 50\n",
+      "building tree 4 of 50\n",
+      "building tree 5 of 50\n",
+      "building tree 6 of 50\n",
+      "building tree 7 of 50\n",
+      "building tree 8 of 50\n",
+      "building tree 9 of 50\n",
+      "building tree 10 of 50\n",
+      "building tree 11 of 50\n",
+      "building tree 12 of 50\n",
+      "building tree 13 of 50\n",
+      "building tree 14 of 50\n",
+      "building tree 15 of 50\n",
+      "building tree 16 of 50\n",
+      "building tree 17 of 50\n",
+      "building tree 18 of 50\n",
+      "building tree 19 of 50\n",
+      "building tree 20 of 50\n",
+      "building tree 21 of 50\n",
+      "building tree 22 of 50\n",
+      "building tree 23 of 50\n",
+      "building tree 24 of 50\n",
+      "building tree 25 of 50\n",
+      "building tree 26 of 50\n",
+      "building tree 27 of 50\n",
+      "building tree 28 of 50\n",
+      "building tree 29 of 50\n",
+      "building tree 30 of 50\n",
+      "building tree 31 of 50\n",
+      "building tree 32 of 50\n",
+      "building tree 33 of 50\n",
+      "building tree 34 of 50\n",
+      "building tree 35 of 50\n",
+      "building tree 36 of 50\n",
+      "building tree 37 of 50\n",
+      "building tree 38 of 50\n",
+      "building tree 39 of 50\n",
+      "building tree 40 of 50\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=2)]: Done  37 tasks      | elapsed:    3.8s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "building tree 41 of 50\n",
+      "building tree 42 of 50\n",
+      "building tree 43 of 50\n",
+      "building tree 44 of 50\n",
+      "building tree 45 of 50\n",
+      "building tree 46 of 50\n",
+      "building tree 47 of 50\n",
+      "building tree 48 of 50\n",
+      "building tree 49 of 50\n",
+      "building tree 50 of 50\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=2)]: Done  50 out of  50 | elapsed:    5.0s finished\n",
+      "INFO[2023-12-08T19:56:57.860] band_classification.train[589] feature importance: [0.09521491 0.03674436 0.02640459 0.03739343 0.05653901 0.03305541\n",
+      " 0.01689697 0.09225835 0.4428657  0.16262727]; accuracy score: 0.9540850165812481\n",
+      "INFO[2023-12-08T19:56:57.866] band_classification.train[1007] end\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [ 20%] [elapsed 0min50sec] [remaining 1min47sec] fitting ⬤\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=1)]: Done  40 tasks      | elapsed:    1.9s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [ 20%] [elapsed 0min51sec] [remaining 1min47sec]:fitting ⬤\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=1)]: Done  40 tasks      | elapsed:    2.1s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [ 81%] [elapsed 0min57sec] [remaining 0min10sec]:writing raster ⚙\u001b[K"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO[2023-12-08T19:57:15.364] band_classification.band_classification[1358] end; prediction: mystorage/classification_rf.tif\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " band classification [ 85%] [elapsed 0min59sec] [remaining 0min10sec]:writing raster ⚙\u001b[K"
+     ]
+    }
+   ],
+   "source": [
+    "classification = rs.band_classification(\n",
+    "    input_bands=1,\n",
+    "    bandset_catalog=catalog,\n",
+    "    spectral_signatures=signature_catalog,\n",
+    "    macroclass=True,\n",
+    "    output_path=working_directory + \"/classification_rf.tif\",\n",
+    "    classification_confidence=True,\n",
+    "    algorithm_name=\"rf\",\n",
+    "    rf_number_trees=50,\n",
+    "    rf_min_samples_split=2,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tMWkcGvsQ-oo"
+   },
+   "source": [
+    "We can display the resulting classification raster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 547
+    },
+    "id": "LNmRizUBmwKI",
+    "outputId": "f6320b92-a902-48d1-a154-564106e12399"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Figure\n",
+    "from osgeo import gdal\n",
+    "import matplotlib.colors as mcolors\n",
+    "import matplotlib.patches as mpatches\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "image = gdal.Open(classification.path)\n",
+    "band = image.GetRasterBand(1).ReadAsArray()\n",
+    "color_map = mcolors.ListedColormap([\"blue\", \"red\", \"green\", \"yellow\"])\n",
+    "plt.imshow(band, cmap=color_map, vmin=1, vmax=4)\n",
+    "plt.rcParams[\"figure.figsize\"] = (15, 15)\n",
+    "plt.axis(\"off\")\n",
+    "legend_handles = [\n",
+    "    mpatches.Patch(color=c, label=str(val))\n",
+    "    for val, c in zip(\n",
+    "        [\"water\", \"built-up\", \"vegetation\", \"soil\"], [\"blue\", \"red\", \"green\", \"yellow\"]\n",
+    "    )\n",
+    "]\n",
+    "plt.legend(\n",
+    "    handles=legend_handles, title=\"Classes\", bbox_to_anchor=(0, 1), loc=\"upper left\"\n",
+    ")\n",
+    "plt.show()\n",
+    "band = image = plt = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "OjcIPOWAtGxj"
+   },
+   "source": [
+    "We can also display the **confidence raster** of the classification, which is a raster having values ranging from 0 (low confidence) to 1 (high confidence).\n",
+    "\n",
+    "We can use this confidence raster to assess the quality of the classification and collect additional training areas to improve the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 547
+    },
+    "id": "Po1wrmVqtHZw",
+    "outputId": "67eb65d6-5ffd-414e-9435-3d22a0cc4b7a"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Figure\n",
+    "from osgeo import gdal\n",
+    "import numpy\n",
+    "import matplotlib.colors as mcolors\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "image = gdal.Open(classification.extra[\"algorithm_raster\"])\n",
+    "band = image.GetRasterBand(1).ReadAsArray()\n",
+    "plt.imshow(band, cmap=\"viridis\", vmin=0, vmax=1)\n",
+    "plt.rcParams[\"figure.figsize\"] = (15, 15)\n",
+    "plt.axis(\"off\")\n",
+    "\n",
+    "color_values = numpy.linspace(0, 1, 5)\n",
+    "color_map = plt.cm.viridis\n",
+    "legend_handles = []\n",
+    "for v in color_values:\n",
+    "    legend_handles.append(mpatches.Patch(color=color_map(v), label=str(v)))\n",
+    "plt.legend(\n",
+    "    handles=legend_handles, title=\"Confidence\", bbox_to_anchor=(0, 1), loc=\"upper left\"\n",
+    ")\n",
+    "\n",
+    "plt.show()\n",
+    "band = image = plt = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gqYCM_LmHrFj"
+   },
+   "source": [
+    "# Close the Session\n",
+    "The session should be closed at the end of all the processes to **remove the temporary files and stop subprocesses**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "id": "MWiXswkipcio"
+   },
+   "outputs": [],
+   "source": [
+    "rs.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "toc_visible": true
+  },
+  "gpuClass": "standard",
+  "kernelspec": {
+   "display_name": "Geo science",
+   "language": "python",
+   "name": "geo"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Notebook illustrating how to perform the Random Forest classification of a Sentinel-2 image.
This tutorial describes how to search and download a Sentinel-2 image from https://dataspace.copernicus.eu  using [Remotior Sensus](https://github.com/semiautomaticgit/remotior_sensus), then prepare the input bands and train a simple Random Forest classification of 4 land cover classes (water, built-up, vegetation, soil).